### PR TITLE
[ 63 ] Responsehandler returns the requested data or an error

### DIFF
--- a/src/main/java/avd/inf/jdm/rentmycar/ResponseHandler.java
+++ b/src/main/java/avd/inf/jdm/rentmycar/ResponseHandler.java
@@ -11,6 +11,7 @@ public class ResponseHandler {
     public static ResponseEntity<Object> generateResponse(String message, HttpStatus status, Object responseObj) {
         Map<String, Object> map = new HashMap<String, Object>();
         map.put("status", status.value());
+        if(status.isError()) map.put("error", status.getReasonPhrase());
         if(responseObj != null) map.put("data", responseObj);
         if(message != null) map.put("message", message);
 


### PR DESCRIPTION
The Responsehandler now returns either the requested data or an error-message. It will always return the status-code.
Because we do not have internal error-codes, there will be no data-field returned on a failed request. We can improve that if we have error-codes, but that documentation is out of our current scope.

![image](https://user-images.githubusercontent.com/83649301/195919503-49fda466-9082-4d01-a623-5a6e97630ae6.png)
